### PR TITLE
Fix typo: "Bebel" => "Babel"

### DIFF
--- a/site/index.hbs
+++ b/site/index.hbs
@@ -97,7 +97,7 @@ title: ''
 * [Less](demos/less.html) - Using the Less plugin.
 * [Stylus](demos/stylus.html) - Using the Stylus plugin.
 * [CoffeeScript](demos/coffeescript.html) - Using the CoffeeScript plugin.
-* [ES2015](demos/es2015.html) - Using the Bebel plugin for ES6/2015 JavaScript support.
+* [ES2015](demos/es2015.html) - Using the Babel plugin for ES6/2015 JavaScript support.
 * [External files](demos/files.html) - Loading external files, instead of using inline content.
 {{/markdown}}
   </section>


### PR DESCRIPTION
Fix for a minor typo on the site