### PR TITLE
Reload iframe before inject new content inside it.

### DIFF
--- a/src/plugins/render.js
+++ b/src/plugins/render.js
@@ -98,9 +98,12 @@ export default class PluginRender {
     if (this.supportSrcdoc) {
       // srcdoc in unreliable in Chrome.
       // https://github.com/ghinda/jotted/issues/23
-      this.$resultFrame.contentWindow.document.open()
-      this.$resultFrame.contentWindow.document.write(this.frameContent)
-      this.$resultFrame.contentWindow.document.close()
+      this.$resultFrame.contentWindow.location.reload(true)
+      this.$resultFrame.onload = function () {
+        this.$resultFrame.contentWindow.document.open()
+        this.$resultFrame.contentWindow.document.write(this.frameContent)
+        this.$resultFrame.contentWindow.document.close()
+      }.bind(this)
     } else {
       // older browsers without iframe srcset support (IE9).
       this.$resultFrame.setAttribute('data-srcdoc', this.frameContent)


### PR DESCRIPTION
Commit message:

This fixes a problem when showing case angular projects. The problem
happens when the context has already loaded angular and new content
comes into play - for example, when live editing using jotted, angular
fails on load its modules again. The solution was then reload the iframe
and then inject the new edited content.

--

Personal message:

Hello @ghinda, here I am again :)

Again with a new PR and don't really know if it makes sense. After the last change that fixed the chrome's iframe loading issues, that broke angular.js showcases that I have. I spent some time trying to figure out the real problem and what I can guess by now is that angular doesn't really let you load things twice in the same context. It seems that it prepares itself and continues executing, but when you try to reload (without reloading in fact) it breaks.

See what you think about this solution and if it's good: good. If you can think of something better, I'd love to see to truly understand what this problem is.

I prepared a small demonstration in here: https://github.com/armoucar/jotted-bug-report

To emulate the error, just edit the code in the HTML tab and observe that the expected js behaviour doesn't happen in the Result tab.