### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Environment for showcasing HTML, CSS and JavaScript, with editable source. It's 
 * [jsDelivr](https://www.jsdelivr.com/projects/jotted):
 
 ``` html
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/jotted/latest/jotted.min.css">
-<script src="https://cdn.jsdelivr.net/jotted/latest/jotted.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/jotted@latest/jotted.min.css">
+<script src="https://cdn.jsdelivr.net/npm/jotted@latest/jotted.min.js"></script>
 ```
 
 ## Features


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jotted.

Feel free to ping me if you have any questions regarding this change.